### PR TITLE
Fix the unordered lists' style

### DIFF
--- a/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
+++ b/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
@@ -288,6 +288,13 @@ h3 {
   margin-bottom: 15px;
   list-style: none;
 }
+
+.rst-content ul.simple li {
+  margin-left: 16px;
+  position: relative;
+  list-style: initial;
+}
+
 .rst-content .section ul li, .rst-content .toctree-wrapper ul li, .wy-plain-list-disc li, article ul li {
   margin-left: 16px;
   position: relative;


### PR DESCRIPTION
The list-style of unordered list defaults to `none`, making the lists difficult to read in TVM's documentation.

Before:
![image](https://user-images.githubusercontent.com/11773619/123653960-30ac7280-d860-11eb-8427-f8ea3150267a.png)

After:
![image](https://user-images.githubusercontent.com/11773619/123653983-37d38080-d860-11eb-8f0c-c8eccb5801cd.png)
