### PR TITLE
Add version selector

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.join(curr_path, "../"))
 # General information about the project.
 project = "tlcpack-sphinx-addon"
 author = "TLCPack Contributors"
-copyright = "2020, %s" % author
+copyright = "2022, %s" % author
 github_doc_root = "https://github.com/tlc-pack/tlpack-sphinx-addon/tree/"
 
 # Version information.
@@ -124,7 +124,7 @@ templates_path = []
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
 
-footer_copyright = "© 2020 TLCPack | All right reserved"
+footer_copyright = "© 2022 TLCPack | All rights reserved"
 footer_note = " ".join(
     """
 TLCPack, tensor learning compiler binary package.""".split(

--- a/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
+++ b/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
@@ -894,6 +894,7 @@ footer .btn.float-right:after {
     font-family: "PT Sans Caption", sans-serif;
     font-size: 15px;
     font-weight: 700;
+    cursor: pointer;
   }
   .wy-nav-top .togglemenu {
     width: 30px;
@@ -1043,4 +1044,58 @@ footer .btn.float-right:after {
 }
 .rst-content .container{
   padding:0;
+}
+
+/* .version-selector-content {
+  display: none;
+}
+
+.version-selector-show .versions-shown {
+  display: none;
+}
+
+.version-selector-show:focus {
+  color: red;
+}
+
+.version-selector-hide, .version-selector-show {
+  cursor: pointer;
+}
+
+.version-selector-show:focus ~ .version-selector-content {
+  display: block;
+}
+.version-selector-show:focus .versions-hidden {
+  display: none;
+}
+.version-selector-show:focus .versions-shown {
+  display: block;
+} */
+
+.version-details {
+  display: none;
+  margin-bottom: 1.5em;
+}
+
+.versions-shown {
+  display: none;
+}
+
+.chevron svg {
+  line-height: 0.5em;
+  margin-top: -10px;
+  height: 1em;
+  transform: translateY(17%);
+}
+
+.version-toggle-box:checked ~ .version-details {
+  display: block;
+}
+
+.version-toggle-box:checked ~ .version-toggle-label .versions-hidden {
+  display: none;
+}
+
+.version-toggle-box:checked ~ .version-toggle-label .versions-shown {
+  display: inline-block;
 }

--- a/tlcpack_sphinx_addon/_templates/footer.html
+++ b/tlcpack_sphinx_addon/_templates/footer.html
@@ -14,17 +14,17 @@
 <div id="button" class="backtop"><img src="{{ theme_asset_url }}/img/right.svg" alt="backtop"/> </div>
 <section class="footerSec">
     <div class="footerHeader">
-      <ul class="d-flex align-md-items-center justify-content-between flex-column flex-md-row">
-        <li class="copywrite d-flex align-items-center">
+      <div class="d-flex align-md-items-center justify-content-between flex-column flex-md-row">
+        <div class="copywrite d-flex align-items-center">
           <h5 id="copy-right-info">{{ footer_copyright }}</h5>
-        </li>
-      </ul>
+        </div>
+      </div>
 
     </div>
 
-    <ul>
-      <li class="footernote">{{ footer_note }}</li>
-    </ul>
+    <div>
+      <div class="footernote">{{ footer_note }}</div>
+    </div>
 
 </section>
 </footer>

--- a/tlcpack_sphinx_addon/_templates/layout.html
+++ b/tlcpack_sphinx_addon/_templates/layout.html
@@ -145,9 +145,23 @@
               {%- set nav_version = current_version %}
             {% endif %}
             {% if nav_version %}
-              {%- if version_selecter is defined %}
-                <div class="version">
-                  <a href="{{ version_selecter }}">{{ nav_version }} ▼ </a>
+              {%- if version_prefixes is defined %}
+              <input type="checkbox" class="version-toggle-box" hidden id="version-toggle">
+              <label for="version-toggle" class="version-toggle-label">
+                  <div tabindex="0" class="version version-selector version-selector-show">
+                    {{ nav_version }} <span class="chevron versions-hidden"><svg fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m8 4 8 8-8 8" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg></span><span class="chevron versions-shown"><svg fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m4 8 8 8 8-8" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg></span>
+                  </div>
+                </label>
+                <div class="version-details wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
+                  <p class="caption" role="heading"><span class="caption-text">Versions</span></p>
+                  <ol style="text-align: left">
+                    {% for version in version_prefixes %}
+                    {% set version_url = "/" if version == "main" else version %}
+                    {% set version_desc = nav_version + " (main)" if version == "main" else version.strip("/") %}
+                    
+                      <li><div class="version"><a style="font-size: 0.8em; padding: 4px" href="{{ version_url }}">{{ version_desc }}</a></div></li>
+                    {% endfor %}
+                  </ol>
                 </div>
               {%- else %}
                 <div class="version">
@@ -196,7 +210,7 @@
             </div>
             <div class="nav-content">
               <!-- {{ project }} -->
-              Table of content
+              Table of Contents
             </div>
         {% endblock %}
       </nav>


### PR DESCRIPTION
This adds a version selector and fixes the old code around it. The versions come from a `conf.py` with something like this (which we will have to add in a follow up PR to apache/tvm/docs/conf.py):
```python
html_context = {
    "version_prefixes": ["main", "v0.8.0/"],
}
```

![dropdown](https://user-images.githubusercontent.com/9407960/172905539-0902d248-f41d-485b-86bc-23168ba15580.gif)


The versions can be accessed by clicking on the current version which has a dropdown chevron by its name. There are also some random other fixes in this PR to some of the copy in the header/footer


cc @areusch