### PR TITLE
Fix paths for static SVGs

### DIFF
--- a/tlcpack_sphinx_addon/_templates/breadcrumbs.html
+++ b/tlcpack_sphinx_addon/_templates/breadcrumbs.html
@@ -71,7 +71,7 @@
           {% elif show_source and source_url_prefix %}
             <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}">{{ _('View page source') }}</a>
           {% elif show_source and has_source and sourcename %}
-            <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> <img src="{{ theme_asset_url }}/img/source.svg" alt="viewsource"/></a>
+            <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> <img src="{{ pathto('_static/img/source.svg', 1) }}" alt="viewsource"/></a>
           {% endif %}
         {% endif %}
       </li>

--- a/tlcpack_sphinx_addon/_templates/footer.html
+++ b/tlcpack_sphinx_addon/_templates/footer.html
@@ -11,7 +11,7 @@
       {% endif %}
     </div>
 {% endif %}
-<div id="button" class="backtop"><img src="{{ theme_asset_url }}/img/right.svg" alt="backtop"/> </div>
+<div id="button" class="backtop"><img src="{{ pathto('_static/img/right.svg', 1) }}" alt="backtop"/> </div>
 <section class="footerSec">
     <div class="footerHeader">
       <div class="d-flex align-md-items-center justify-content-between flex-column flex-md-row">


### PR DESCRIPTION
These have a `//` in the URL when rendered which the Apache server serves up fine but is messed up for PR docs served from S3/CloudFront.

cc @tqchen @areusch 