### PR TITLE
Fix index link text color for current sphinx-gallery version

### DIFF
--- a/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
+++ b/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
@@ -164,7 +164,7 @@ h3 {
     border: none;
   }
 }
-.rst-content .sphx-glr-thumbcontainer a.internal {
+.rst-content .sphx-glr-thumbcontainer div {
   bottom: 0;
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
After the `sphinx-gallery` version was updated by https://github.com/apache/tvm/pull/10921, it became difficult to see the text color of links in the gallery index page:

![image](https://user-images.githubusercontent.com/3069006/173897213-b4a1285c-193c-4d0c-998c-bd77657c309d.png)

This occurred because of a change in the way the text was displayed in HTML. Previously, the text elements had the following structure:
```html
<div class="sphx-glr-thumbcontainer" tooltip="This tutorial is an introduction to working with microTVM and a TFLite model with Relay.">
  <div class="figure align-default" id="id3">
    <img alt="../../_images/sphx_glr_micro_tflite_thumb.png" src="../../_images/sphx_glr_micro_tflite_thumb.png">
    <p class="caption">
      <span class="caption-text">
        <a class="reference internal" href="micro_tflite.html#sphx-glr-how-to-work-with-microtvm-micro-tflite-py">
          <span class="std std-ref">microTVM with TFLite Models</span>
        </a>
      </span>
      <a class="headerlink" href="#id3" title="Permalink to this image">¶</a>
    </p>
  </div>
</div>
```
However, in current versions this is instead, where the `<a>` tag is stylized to make everything in the outer `<div>` a link:
```html
<div class="sphx-glr-thumbcontainer" tooltip="This tutorial is an introduction to working with microTVM and a TFLite model with Relay.">
  <img alt="microTVM with TFLite Models" src="../../_images/sphx_glr_micro_tflite_thumb.png">
  <p>
    <a class="reference internal" href="micro_tflite.html#sphx-glr-how-to-work-with-microtvm-micro-tflite-py">
      <span class="std std-ref">microTVM with TFLite Models</span>
    </a>
  </p>
  <div class="sphx-glr-thumbnail-title">microTVM with TFLite Models</div>
</div>
```

Because of this change, our previous CSS rule (`.rst-content .sphx-glr-thumbcontainer a.internal`) is unable to locate the relevant text, and is unable to make it white. This PR changes that selector to fix the bug and make the text display correctly again.