### PR TITLE
Fix link target for gallery cards

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """Setup TLCPack."""
 from setuptools import setup, find_packages
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 setup(

--- a/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
+++ b/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
@@ -177,6 +177,7 @@ h3 {
   font-size: 16px;
   color: #ffffff;
   font-style: normal;
+  pointer-events: none;
 }
 .rst-content .sphx-glr-thumbcontainer .figure {
   margin: 0;


### PR DESCRIPTION
This fixes https://github.com/apache/tvm/issues/12156 by ignoring events on the `div` that covers the underlying `a`