### PR TITLE
Remove empty code blocks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """Setup TLCPack."""
 from setuptools import setup, find_packages
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 setup(

--- a/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
+++ b/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
@@ -177,7 +177,6 @@ h3 {
   font-size: 16px;
   color: #ffffff;
   font-style: normal;
-  pointer-events: none;
 }
 .rst-content .sphx-glr-thumbcontainer .figure {
   margin: 0;

--- a/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
+++ b/tlcpack_sphinx_addon/_static/css/tlcpack_theme.css
@@ -177,6 +177,7 @@ h3 {
   font-size: 16px;
   color: #ffffff;
   font-style: normal;
+  pointer-events: none;
 }
 .rst-content .sphx-glr-thumbcontainer .figure {
   margin: 0;

--- a/tlcpack_sphinx_addon/_static/js/tlcpack_theme.js
+++ b/tlcpack_sphinx_addon/_static/js/tlcpack_theme.js
@@ -40,3 +40,9 @@ $(window).scroll(function() {
   }
 });
 
+// Remove empty code blocks
+document.querySelectorAll("div.highlight > pre").forEach(p => {
+  if (p.innerText.trim() === "") {
+      p.parentNode.removeChild(p);
+  }
+})


### PR DESCRIPTION
See https://github.com/apache/tvm/issues/12343 for context, this is a
quick fix to get rid of the offending code blocks. In the end we should
probably fix this either after generating docs or in sphinx-gallery
itself.