### PR TITLE
Fix for Sphinx 7.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """Setup TLCPack."""
 from setuptools import setup, find_packages
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 
 setup(

--- a/tlcpack_sphinx_addon/_templates/layout.html
+++ b/tlcpack_sphinx_addon/_templates/layout.html
@@ -18,6 +18,9 @@
 {%- set sphinx_writer = 'writer-html5' if html5_doctype else 'writer-html4' %}
 {% set theme_asset_url = theme_asset_url | default(pathto('_static/',1 )) %}
 
+{%- set (_ver_major, _ver_minor) = (sphinx_version.split('.') | list)[:2] | map('int') -%}
+{%- set sphinx_version_info = (_ver_major, _ver_minor, -1) -%}
+
 <!DOCTYPE html>
 <html class="{{ sphinx_writer }}" lang="{{ lang_attr }}" >
 <head>
@@ -30,7 +33,9 @@
 
   {# CSS #}
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-  <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+  {%- if sphinx_version_info < (4, 0) -%}
+    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+  {%- endif %}
   {%- for css in css_files %}
     {%- if css|attr("rel") %}
   <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
@@ -158,7 +163,7 @@
                     {% for version in version_prefixes %}
                     {% set version_url = "/" if version == "main" else version %}
                     {% set version_desc = nav_version + " (main)" if version == "main" else version.strip("/") %}
-                    
+
                       <li><div class="version"><a style="font-size: 0.8em; padding: 4px" href="{{ version_url }}">{{ version_desc }}</a></div></li>
                     {% endfor %}
                   </ol>


### PR DESCRIPTION
As the `style` key is removed in Sphinx 7.0.0 ([ref](https://github.com/sphinx-doc/sphinx/pull/11381/files)).

The change is based on the (codes in sphinx_rtd_theme)[https://github.com/readthedocs/sphinx_rtd_theme/blob/2.0.0/sphinx_rtd_theme/layout.html#L27-L30]

Tested on Sphinx both 5.2.3 and 7.2.6. 

cc @tqchen 