### PR TITLE
Fix version number in __init__.py

### DIFF
--- a/tlcpack_sphinx_addon/__init__.py
+++ b/tlcpack_sphinx_addon/__init__.py
@@ -1,7 +1,7 @@
 """TLCPack sphinx add on"""
 import os
 
-__version__ = "0.1.6"
+__version__ = "0.2.3"
 
 __BASEDIR__ = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
 


### PR DESCRIPTION
When I update relay docs, founding the version number is strange like below:

![image](https://github.com/user-attachments/assets/428e36c5-a5e2-45ac-9882-7043e3140f29)

cc @Hzfengsy @tqchen 
